### PR TITLE
Data classes but with factories

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.1.0'
 
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
 
     implementation 'androidx.navigation:navigation-fragment-ktx:2.2.2'

--- a/app/src/main/java/co/zsmb/viewstatesdemo/Util.kt
+++ b/app/src/main/java/co/zsmb/viewstatesdemo/Util.kt
@@ -1,3 +1,11 @@
 package co.zsmb.viewstatesdemo
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
+
 inline val <T> T.exhaustive get() = this
+
+inline fun <T, A> LiveData<T>.select(
+    crossinline property: T.() -> A
+) = map(property).distinctUntilChanged()

--- a/app/src/main/java/co/zsmb/viewstatesdemo/Util.kt
+++ b/app/src/main/java/co/zsmb/viewstatesdemo/Util.kt
@@ -1,5 +1,7 @@
 package co.zsmb.viewstatesdemo
 
+import android.view.View
+import androidx.core.view.isVisible
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
@@ -9,3 +11,7 @@ inline val <T> T.exhaustive get() = this
 inline fun <T, A> LiveData<T>.select(
     crossinline property: T.() -> A
 ) = map(property).distinctUntilChanged()
+
+fun View.setVisible(isVisible: Boolean) {
+    this.isVisible = isVisible
+}

--- a/app/src/main/java/co/zsmb/viewstatesdemo/upload/UploadViewModel.kt
+++ b/app/src/main/java/co/zsmb/viewstatesdemo/upload/UploadViewModel.kt
@@ -3,6 +3,7 @@ package co.zsmb.viewstatesdemo.upload
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.zsmb.viewstatesdemo.select
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.random.Random
@@ -10,40 +11,42 @@ import kotlin.random.nextLong
 
 class UploadViewModel : ViewModel() {
 
-    val viewState = MutableLiveData<UploadViewState>()
+    private val viewState = MutableLiveData<UploadViewState>()
+
+    fun <T> select(property: UploadViewState.() -> T) = viewState.select(property)
 
     init {
-        viewState.value = Initial
+        viewState.value = UploadViewState.initial()
     }
 
     fun startUpload() {
         viewModelScope.launch {
-            viewState.value = Initial
-            viewState.value = UploadInProgress(10)
+            viewState.value = UploadViewState.initial()
+            viewState.value = UploadViewState.uploadInProgress(10)
             delay()
-            viewState.value = UploadInProgress(30)
+            viewState.value = UploadViewState.uploadInProgress(30)
             delay()
-            viewState.value = UploadInProgress(42)
+            viewState.value = UploadViewState.uploadInProgress(42)
             delay()
-            viewState.value = UploadInProgress(50)
+            viewState.value = UploadViewState.uploadInProgress(50)
             delay()
 
             if (Random.nextBoolean()) {
-                viewState.value = UploadFailed
+                viewState.value = UploadViewState.uploadFailed()
                 return@launch
             }
 
-            viewState.value = UploadInProgress(70)
+            viewState.value = UploadViewState.uploadInProgress(70)
             delay()
-            viewState.value = UploadInProgress(90)
+            viewState.value = UploadViewState.uploadInProgress(90)
             delay()
-            viewState.value = UploadInProgress(94)
+            viewState.value = UploadViewState.uploadInProgress(94)
             delay()
-            viewState.value = UploadInProgress(99)
+            viewState.value = UploadViewState.uploadInProgress(99)
             delay()
-            viewState.value = UploadInProgress(100)
+            viewState.value = UploadViewState.uploadInProgress(100)
 
-            viewState.value = UploadSuccess
+            viewState.value = UploadViewState.uploadSuccess()
         }
     }
 

--- a/app/src/main/java/co/zsmb/viewstatesdemo/upload/UploadViewState.kt
+++ b/app/src/main/java/co/zsmb/viewstatesdemo/upload/UploadViewState.kt
@@ -1,11 +1,32 @@
 package co.zsmb.viewstatesdemo.upload
 
-sealed class UploadViewState
+data class UploadViewState(
+    val isProgressVisible: Boolean = false,
+    val progressPercentage: Int = 0,
+    val isUploadDoneVisible: Boolean = false,
+    val isStatusTextVisible: Boolean = false,
+    val statusText: String = "",
+    val isRetryVisible: Boolean = false
+) {
 
-object Initial : UploadViewState()
+    companion object {
+        fun initial() = UploadViewState()
 
-data class UploadInProgress(val percentage: Int) : UploadViewState()
+        fun uploadInProgress(percentage: Int) = initial().copy(
+            isProgressVisible = true,
+            progressPercentage = percentage
+        )
 
-object UploadFailed : UploadViewState()
+        fun uploadFailed() = initial().copy(
+            isStatusTextVisible = true,
+            statusText = "Sorry, something went wrong.",
+            isRetryVisible = true
+        )
 
-object UploadSuccess : UploadViewState()
+        fun uploadSuccess() = initial().copy(
+            isUploadDoneVisible = true,
+            isStatusTextVisible = true,
+            statusText = "Upload complete!"
+        )
+    }
+}


### PR DESCRIPTION
First of all, thank you very much for sharing your blogpost. It was definitely the best read I've had around the topic :)

I'm opening this PR to share an extra interesting idea of how to handle the view state and I'd love to get your input on it. A big disclaimer is that this isn't my idea, I got it from [Philipp Ebert](https://twitter.com/tehultrah) after I shared your blogpost with him. I thought it was pretty relevant and decided to open this PR.

----

The motivation for the approach here is to avoid the long, error-prone blocks of code you mentioned we end up with when we're in a sealed class world. Not only that, but to avoid any kind of logic in the view, and go back to a state where the view is simply reflecting the view state, instead of making decisions based on it.

The idea is pretty simple: we go back to data classes, but we expose factory methods to create instances of it. This won't prevent people from creating "invalid" instances of the class, since even if we make the constructor private, the `copy()` method is always accessible. But given the usual limited scope of view state classes, I believe the existence of the factory methods are good enough.

By going back to data classes with simple properties that describe how the UI should look like, we're able to simplify the fragment code significantly, which is the main point of this approach. There's a few more details in the commit messages, but that's the gist of it.